### PR TITLE
Fix alias conflict for spelltype names

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -203,7 +203,7 @@ int bot_command_init(void)
 		bot_command_add("spellsettingstoggle", "Toggle a bot spell use", AccountStatus::Player, bot_command_spell_settings_toggle) ||
 		bot_command_add("spellsettingsupdate", "Update a bot spell setting entry", AccountStatus::Player, bot_command_spell_settings_update) ||
 		bot_command_add("spelltypeids", "Lists spelltypes by ID", AccountStatus::Player, bot_command_spelltype_ids) ||
-		bot_command_add("spelltypenames", "Lists spelltypes by shortname", AccountStatus::Player, bot_command_spelltype_names) ||
+                bot_command_add("spelltype_shortnames", "Lists spelltypes by shortname", AccountStatus::Player, bot_command_spelltype_names) ||
 		bot_command_add("suspend", "Suspends a bot's AI processing until released", AccountStatus::Player, bot_command_suspend) ||
 		bot_command_add("taunt", "Toggles taunt use by a bot", AccountStatus::Player, bot_command_taunt) ||
 		bot_command_add("timer", "Checks or clears timers of the chosen type.", AccountStatus::GMMgmt, bot_command_timer) ||

--- a/zone/client_bot.cpp
+++ b/zone/client_bot.cpp
@@ -296,7 +296,7 @@ void Client::SendSpellTypePrompts(bool commanded_types, bool client_only_types) 
 					fmt::format("^spelltypeids client"), "ID"
 				),
 				Saylink::Silent(
-					fmt::format("^spelltypenames client"), "Shortname"
+                                    fmt::format("^spelltype_shortnames client"), "Shortname"
 				)
 			).c_str()
 		);
@@ -316,13 +316,13 @@ void Client::SendSpellTypePrompts(bool commanded_types, bool client_only_types) 
 					fmt::format("^spelltypeids 40+"), "40+"
 				),
 				Saylink::Silent(
-					fmt::format("^spelltypenames 0-19"), "Shortname 0-19"
+                                    fmt::format("^spelltype_shortnames 0-19"), "Shortname 0-19"
 				),
 				Saylink::Silent(
-					fmt::format("^spelltypenames 20-39"), "20-39"
+                                    fmt::format("^spelltype_shortnames 20-39"), "20-39"
 				),
 				Saylink::Silent(
-					fmt::format("^spelltypenames 40+"), "40+"
+                                    fmt::format("^spelltype_shortnames 40+"), "40+"
 				)
 			).c_str()
 		);
@@ -337,7 +337,7 @@ void Client::SendSpellTypePrompts(bool commanded_types, bool client_only_types) 
 					fmt::format("^spelltypeids commanded"), "ID"
 				),
 				Saylink::Silent(
-					fmt::format("^spelltypenames commanded"), "Shortname"
+                                    fmt::format("^spelltype_shortnames commanded"), "Shortname"
 				)
 			).c_str()
 		);


### PR DESCRIPTION
## Summary
- rename the `spelltypenames` command to `spelltype_shortnames`
- update saylink references to the new command

## Testing
- `cmake -G "Unix Makefiles" -DEQEMU_BUILD_TESTS=OFF -DEQEMU_BUILD_LOGIN=OFF ..`
- `make -j4 zone` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6859966972e48327a0f3abc9c323f5e7