### PR TITLE
Prevent clearing bag ornamentation when adding augments

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -612,11 +612,14 @@ bool EQ::ItemInstance::UpdateOrnamentationInfo()
 		}
 	}
 
-	SetOrnamentIcon(0);
-	SetOrnamentHeroModel(0);
-	SetOrnamentationIDFile(0);
+       if (!(m_ornamenticon || m_ornamentidfile || m_ornament_hero_model)) {
+               SetOrnamentIcon(0);
+               SetOrnamentHeroModel(0);
+               SetOrnamentationIDFile(0);
+               return false;
+       }
 
-	return false;
+       return true;
 }
 
 bool EQ::ItemInstance::CanTransform(const ItemData *ItemToTry, const ItemData *Container, bool AllowAll) {


### PR DESCRIPTION
## Summary
- keep ornament visuals when adding a normal augment

## Testing
- `cmake -S . -B build -DEQEMU_BUILD_TESTS=ON` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_687ae9a956348327b5d858d0cfb636d8